### PR TITLE
fix: methodWrapper because usedMethods are always null

### DIFF
--- a/src/components/taskComponents/mixins/ContextMenu.vue
+++ b/src/components/taskComponents/mixins/ContextMenu.vue
@@ -38,11 +38,9 @@ export default {
     };
 
     const methodWrapper = (method: Function) => {
-      const usedMethods = getProperty(`nodes__${currentNode}__components__${props.componentId}__contextMenu__usedMethods`);
-      console.log(usedMethods);
       setProperty({
         path: `nodes__${currentNode}__components__${props.componentId}__contextMenu__usedMethods`,
-        value: [...usedMethods, method.name]
+        value: method.name
       });
 
       method();


### PR DESCRIPTION
current program crashes because null is not iterable (spread syntax won't work)
as from my tests usedMethods are always null, so i removed this part

Let me know if this helps